### PR TITLE
shrunk the size of the website to make room for the UI

### DIFF
--- a/src/components/level_prototype.css
+++ b/src/components/level_prototype.css
@@ -1,0 +1,8 @@
+
+
+div.minification {
+    scale: 0.80;
+    margin-top: -50px;
+    border: 3px solid black;
+    box-shadow: 6px 6px 5px grey;
+}

--- a/src/components/level_prototype.jsx
+++ b/src/components/level_prototype.jsx
@@ -1,6 +1,7 @@
 import React, {Component, useEffect, useState, Suspense} from 'react';
 import Browser_Bar from './browser_bar.jsx'
 import UI_Overlay from './ui_overlay.jsx'
+import './level_prototype.css'
 
 export default class Level_Prototype extends Component {
     constructor(props){
@@ -23,11 +24,13 @@ export default class Level_Prototype extends Component {
         const Level = this.loadLevel(this.props.level.levelNum)
         return (
             <div>
-                <Browser_Bar url = {this.props.level.url}/>
+                <div className="minification">
+                    <Browser_Bar url = {this.props.level.url}/>
+                    <Suspense fallback={<div>Loading Level...</div>}>
+                        <Level />
+                    </Suspense>
+                </div>
                 <UI_Overlay level = {this.props.level}/>
-                <Suspense fallback={<div>Loading Level...</div>}>
-                    <Level />
-                </Suspense>
             </div>
         )
     }


### PR DESCRIPTION
After discussing, we are shrinking the size of the faux-websites to make room for the UI. This is done by creating a css file and wrapping a div around the level prototype object, and simply setting the scale of the div to be 80%.