### PR TITLE
added scaling that will work outside of firefox

### DIFF
--- a/src/components/level_prototype.css
+++ b/src/components/level_prototype.css
@@ -1,7 +1,7 @@
 
 
 div.minification {
-    scale: 0.80;
+    transform: scale(0.80);
     margin-top: -50px;
     border: 3px solid black;
     box-shadow: 6px 6px 5px grey;


### PR DESCRIPTION
The scale css property only works in firefox, so I had to change it to transform: scale(x.xx) to allow it to work in other browsers.